### PR TITLE
Heatmap has wrong labels - FIXED

### DIFF
--- a/PairsTrading.ipynb
+++ b/PairsTrading.ipynb
@@ -859,7 +859,7 @@
     "scores, pvalues, pairs = find_cointegrated_pairs(df)\n",
     "import seaborn\n",
     "fig, ax = plt.subplots(figsize=(10,10))\n",
-    "seaborn.heatmap(pvalues, xticklabels=tickers, yticklabels=tickers, cmap='RdYlGn_r' \n",
+    "seaborn.heatmap(pvalues, xticklabels=df.columns, yticklabels=df.columns, cmap='RdYlGn_r' \n",
     "                , mask = (pvalues >= 0.05)\n",
     "                )\n",
     "print(pairs)"


### PR DESCRIPTION
Changed xticklabels and yticklabels to use df.columns since using tickers, which results in the wrong order of labels being used (hence the cointegrated pairs shown in the map do not match the actual pairs)